### PR TITLE
ビルドエラー修正

### DIFF
--- a/Assets/App/Scripts/UI/Common/Modal.cs
+++ b/Assets/App/Scripts/UI/Common/Modal.cs
@@ -2,10 +2,12 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using UnityEditor;
-using UnityEditor.UI;
 using UnityEngine;
 using UnityEngine.UI;
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEditor.UI;
+#endif
 
 namespace Flappy.UI
 {


### PR DESCRIPTION
プリプロセッサ書き忘れてたせいでをビルド時にUnityEditorが参照できないのでエラーになってた