### PR TITLE
スコアゲージの表示を微調整

### DIFF
--- a/Assets/App/Fonts/RocknRollOne/RocknRollOne-Regular SDF SoftShadow.mat
+++ b/Assets/App/Fonts/RocknRollOne/RocknRollOne-Regular SDF SoftShadow.mat
@@ -71,7 +71,7 @@ Material:
     - _OutlineSoftness: 0
     - _OutlineUVSpeedX: 0
     - _OutlineUVSpeedY: 0
-    - _OutlineWidth: 0
+    - _OutlineWidth: 0.1
     - _PerspectiveFilter: 0.875
     - _Reflectivity: 10
     - _ScaleRatioA: 0.6666667

--- a/Assets/App/Scripts/Scenes/PlayGame/ScoreGauge.cs
+++ b/Assets/App/Scripts/Scenes/PlayGame/ScoreGauge.cs
@@ -61,6 +61,9 @@ namespace Flappy.PlayGame
 			}
 			else
 			{
+				// 最高スコアが0の時はゲージを緑に塗りつぶしておく
+				this.currentScoreMask.fillAmount = 1f;
+
 				// 最高スコアが0の時は最高スコアアイコンを非表示にする
 				this.bestIcon.gameObject.SetActive(false);
 


### PR DESCRIPTION
- テキストの影を少しだけ濃くした
- 最高スコア0の時にゲージを緑に塗りつぶすように